### PR TITLE
Update to default brightnesss and minimum kelvin values

### DIFF
--- a/lifx-poly.py
+++ b/lifx-poly.py
@@ -19,7 +19,7 @@ import math
 LOGGER = udi_interface.LOGGER
 Custom = udi_interface.Custom
 BR_INCREMENT = 2620    # this is ~4% of 65535
-BR_MIN = 1310          # minimum brightness value ~2%
+BR_MIN = 335          # minimum brightness value ~2%
 BR_MAX = 65535         # maximum brightness value
 FADE_INTERVAL = 5000   # 5s
 BRTDIM_INTERVAL = 400  # 400ms

--- a/profile/editor/editors.xml
+++ b/profile/editor/editors.xml
@@ -9,7 +9,7 @@
     </editor>
     <!-- LIFX Kelvin Editor -->
     <editor id="lifxkelvin">
-        <range uom="26" min="2500" max="9000" prec="0" step="1" />
+        <range uom="26" min="1" max="9000" prec="0" step="1" />
     </editor>
     <!-- LIFX Uptime Editor -->
     <editor id="lifxuptime">


### PR DESCRIPTION
Change the minimum brightness value in edit "lifx-poly.py" line 22 from 255 to 335

BR_MIN = 335          # minimum brightness value ~1%

Change the minimum Kelvin value in "editors.xml"  from 2500 to 1. 

<range uom="26" min="1500" max="9000" prec="0" step="1" />